### PR TITLE
Cache ipinfo call using backend service and IpInfoLite

### DIFF
--- a/src/app/services/network.service.ts
+++ b/src/app/services/network.service.ts
@@ -1,6 +1,4 @@
 import { Injectable } from '@angular/core';
-import { map, catchError } from 'rxjs/operators';
-import { throwError } from 'rxjs';
 import { Network } from '@awesome-cordova-plugins/network/ngx';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { environment } from 'src/environments/environment';
@@ -23,6 +21,17 @@ type Ip4Data = {
   timezone: string;
 };
 
+type IpInfoLiteData = {
+  ip: string;
+  asn: string;
+  as_name: string;
+  as_domain: string;
+  country_code: string;
+  country: string;
+  continent_code: string;
+  continent: string;
+};
+
 type IpInfoData = {
   ip: string;
   hostname: string;
@@ -40,6 +49,7 @@ type IpInfoData = {
 })
 export class NetworkService {
   accessServiceUrl = environment.restAPI + 'ip-metadata';
+  ipInfoLiteUrl = 'https://api.ipinfo.io/lite/me?token=9906baf67eda8b'; //ONLY FOR LOCAL DEV TESTING
   // accessServiceUrl = 'https://ipinfo.io?token=060bdd9da6a22f'; //ONLY FOR LOCAL DEV TESTING
   headers: any;
   options: any;
@@ -55,18 +65,46 @@ export class NetworkService {
     this.headers = headersItem;
   }
 
+  // this function has a retrie logic of 3 times with exponential wait
+  async getIpFromIpLite(): Promise<IpInfoLiteData> {
+    console.log('getIpFromIpLite');
+    const options = { headers: this.headers };
+    let response = null;
+    let retryCount = 0;
+    const maxRetries = 3;
+
+    while (retryCount < maxRetries) {
+      try {
+        console.log('accessServiceUrl', this.ipInfoLiteUrl);
+        response = (await this.http.get(this.ipInfoLiteUrl, options).toPromise<any>()) as IpInfoLiteData;
+        console.log('response', response);
+        return response;
+      } catch (error) {
+        console.error('Error:', error);
+        retryCount++;
+        if (retryCount < maxRetries) {
+          const waitTime = Math.pow(2, retryCount) * 1000; // Exponential backoff
+          await new Promise((resolve) => setTimeout(resolve, waitTime));
+        }
+      }
+    }
+    throw new Error('Failed to retrieve IP information after multiple attempts.');
+  }
+
+
   /**
    * Retrieves network information.
    * @returns {Promise<any>} A promise that resolves to the network information.
    */
   async getNetInfo() {
+    const ipInfoLite = await this.getIpFromIpLite();
     console.log('getNetInfo');
     const options = { headers: this.headers };
     let response = null;
     try {
       console.log('accessServiceUrl', this.accessServiceUrl);
       response = this.standardData(
-        await this.http.get(this.accessServiceUrl, options).toPromise<any>()
+        await this.http.get(`${this.accessServiceUrl}/${ipInfoLite.ip}`, options).toPromise<any>()
       );
     } catch (error) {
       console.error('Error:', error);

--- a/src/app/services/network.service.ts
+++ b/src/app/services/network.service.ts
@@ -3,6 +3,7 @@ import { map, catchError } from 'rxjs/operators';
 import { throwError } from 'rxjs';
 import { Network } from '@awesome-cordova-plugins/network/ngx';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { environment } from 'src/environments/environment';
 
 type Ip4Data = {
   organization: string;
@@ -38,7 +39,7 @@ type IpInfoData = {
   providedIn: 'root',
 })
 export class NetworkService {
-  accessServiceUrl = 'https://ipinfo.io?token=9906baf67eda8b';
+  accessServiceUrl = environment.restAPI + 'ip-metadata';
   // accessServiceUrl = 'https://ipinfo.io?token=060bdd9da6a22f'; //ONLY FOR LOCAL DEV TESTING
   headers: any;
   options: any;
@@ -63,9 +64,10 @@ export class NetworkService {
     const options = { headers: this.headers };
     let response = null;
     try {
-      response = this.standardData(await this.http
-        .get(this.accessServiceUrl, options)
-        .toPromise<any>());
+      console.log('accessServiceUrl', this.accessServiceUrl);
+      response = this.standardData(
+        await this.http.get(this.accessServiceUrl, options).toPromise<any>()
+      );
     } catch (error) {
       console.error('Error:', error);
       const ipGeoResponse = await fetch('https://ipv4.geojs.io/v1/ip/geo.json');
@@ -78,7 +80,7 @@ export class NetworkService {
   private mapData(source: Ip4Data): IpInfoData {
     return this.standardData({
       ip: source.ip,
-      
+
       hostname: source.ip,
       city: source.city ?? '',
       region: source.region ?? '',


### PR DESCRIPTION
This PR updates the way we retrieve IP and network metadata from IpInfo in order to optimize usage and reduce costs.

Previously, the app made direct calls to IpInfo Core to obtain both the IP address and metadata, which are rate-limited and require a paid plan.

With this update:
	•	The device now uses IpInfo Lite, a free and unlimited service, to retrieve only the public IP address.
	•	That IP is then sent to the backend, which performs the call to IpInfo Core to get the full metadata.
	•	The backend stores this metadata in the database and returns it to the client.
	•	If the same IP is requested again, the backend returns the cached data from the DB instead of calling IpInfo Core again.

This approach significantly reduces the number of calls made to IpInfo Core, preserving quota and lowering associated costs.