### PR TITLE
Add missing client_name to staticMetadata in ndt7

### DIFF
--- a/src/assets/js/ndt/ndt7.js
+++ b/src/assets/js/ndt/ndt7.js
@@ -20,6 +20,7 @@
     const staticMetadata = {
       'client_library_name': 'ndt7-js',
       'client_library_version': '0.0.6',
+      'client_name': 'giga-client',
     };
     // cb creates a default-empty callback function, allowing library users to
     // only need to specify callback functions for the events they care about.

--- a/src/assets/js/ndt/ndt7.js
+++ b/src/assets/js/ndt/ndt7.js
@@ -20,7 +20,7 @@
     const staticMetadata = {
       'client_library_name': 'ndt7-js',
       'client_library_version': '0.0.6',
-      'client_name': 'giga-client',
+      'client_name': 'giga-meter',
     };
     // cb creates a default-empty callback function, allowing library users to
     // only need to specify callback functions for the events they care about.


### PR DESCRIPTION
Include the client_name field in the staticMetadata object for ndt7 to provide additional context about the client.