### PR TITLE
Add separate electron-builder signed config for signed builds

### DIFF
--- a/electron/electron-builder.signed.config.json
+++ b/electron/electron-builder.signed.config.json
@@ -1,0 +1,27 @@
+{
+  "appId": "com.unicef.pdca",
+  "productName": "Giga Meter",
+  "artifactName": "Giga-Meter-Setup-${version}.${ext}",
+  "directories": {
+    "buildResources": "resources"
+  },
+  "files": ["assets/**/*", "build/**/*", "capacitor.config.*", "app/**/*"],
+  "nsis": {
+    "allowElevation": true,
+    "oneClick": false,
+    "deleteAppDataOnUninstall": true,
+    "allowToChangeInstallationDirectory": true
+  },
+  "win": {
+    "target": "nsis",
+    "icon": "assets/appIcon.ico",
+    "signingHashAlgorithms": ["sha256"],
+    "certificateSubjectName": "UNICEF",
+    "rfc3161TimeStampServer": "http://timestamp.digicert.com",
+    "sign": "./resources/sign.js"
+  },
+  "mac": {
+    "category": "your.app.category.type",
+    "target": "dmg"
+  }
+}

--- a/electron/package.json
+++ b/electron/package.json
@@ -21,8 +21,8 @@
     "electron:pack": "npm run build && electron-builder build --dir -c ./electron-builder.config.json",
     "electron:make": "npm run build && electron-builder build -c ./electron-builder.config.json -p always --x64 --ia32",
     "electron:make-not-publish": "npm run build && electron-builder build -c ./electron-builder.config.json always --x64 --ia32",
-    "electron:make-signed": "npm run build && electron-builder build -c ./electron-builder.config.json -p always --x64 --ia32",
-    "electron:make-signed-no-publish": "npm run build && electron-builder build -c ./electron-builder.config.json --x64 --ia32"
+    "electron:make-signed": "npm run build && electron-builder build -c ./electron-builder.signed.config.json -p always --x64 --ia32",
+    "electron:make-signed-no-publish": "npm run build && electron-builder build -c ./electron-builder.signed.config.json --x64 --ia32"
   },
   "dependencies": {
     "@capacitor-community/electron": "^4.1.0",


### PR DESCRIPTION
## Summary
- Adds `electron/electron-builder.signed.config.json` mirroring the base config plus active `win.sign`, `certificateSubjectName`, `signingHashAlgorithms`, and `rfc3161TimeStampServer` fields for DigiCert KeyLocker signing.
- Points `electron:make-signed` and `electron:make-signed-no-publish` at the new signed config so the default `electron:make` / `electron:make-not-publish` scripts continue producing unsigned builds.

## Test plan
- [ ] `npm run electron:make-not-publish` — verify build completes without invoking `sign.js`.
- [ ] `npm run electron:make-signed-no-publish` on a signing-enabled machine — verify `sign.js` runs and the installer is signed.